### PR TITLE
reset stickyLine while not sticking

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -344,7 +344,7 @@
             return prevOffset + $scope.getScrollTop();
 
           }, function(newVal, oldVal) {
-            if ((typeof stickyLine === 'undefined') && newVal !== 0 && !isSticking) {
+            if (((typeof stickyLine === 'undefined') || !isSticking) && newVal !== 0) {
               stickyLine = newVal - offset;
               // IF the sticky is confined, we want to make sure the parent is relatively positioned,
               // otherwise it won't bottom out properly


### PR DESCRIPTION
This prevents issues where elements added after a watch move the sticky element around do not update the stickyLine